### PR TITLE
depend-on-by: fix attributes values

### DIFF
--- a/templates/depended-on-by.tt2
+++ b/templates/depended-on-by.tt2
@@ -10,10 +10,10 @@
 
 		<div id="menu">
 			<a href="https://github.com/DrHyde/CPANdeps" class="first">Source code</a> 
-			<a href=static/reportbug.html>Report a bug in this site</a>
+			<a href="static/reportbug.html">Report a bug in this site</a>
 			<a href="/static/credits.html">Credits</a>
-			<a href=depended-on-by.pl>Reverse lookup</a>
-			<a href=static/links.html class="last">Links</a>
+			<a href="depended-on-by.pl">Reverse lookup</a>
+			<a href="static/links.html" class="last">Links</a>
 		</div>
 		
   </p>


### PR DESCRIPTION
Fix attributes values as this is XHTML, so this should follow XML rules: quotes around attribute values are mandatory.

See thoses issues and a few other with the [W23C validator](http://validator.w3.org/check?verbose=1&uri=http%3A%2F%2Fdeps.cpantesters.org%2Fdepended-on-by.pl%3Fdist%3DPOE-Component-Schedule-0.95).
